### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,18 @@ Users could choose to install Anaconda, if they want. If using Anaconda or Entho
 
 ## Setup Guide
 
-####Clone the repository
+#### Clone the repository
     $ git clone https://github.com/amitkaps/weed.git
 
-####Create a virtual environment & activate
+#### Create a virtual environment & activate
     $ cd weed
     $ virtualenv env
     $ source env/bin/activate
 
-####Install reqirements from requirements file
+#### Install reqirements from requirements file
     $ pip install -r requirements.txt
 
-####Note: Make sure you have libraries for png & freetype.
+#### Note: Make sure you have libraries for png & freetype.
 Ubuntu users can install the below
 
     apt-get install libfreetype6-dev


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
